### PR TITLE
Fixed client's internal name for the launcher

### DIFF
--- a/worlds/ape_escape_3/data/Strings.py
+++ b/worlds/ape_escape_3/data/Strings.py
@@ -2009,7 +2009,7 @@ class APConsole:
         decor =         "||==========================================||"
         greet =         " Welcome to Ape Escape 3 Archipelago!"
         game_name =     " Ape Escape 3 Archipelago"
-        client_name =   " Ape Escape 3 Client"
+        client_name =   "Ape Escape 3 Client"
         client_ver =    " Client v1.0.80"
         world_ver =     " World v1.0.72"
 


### PR DESCRIPTION
For the ArchipelagoLauncher, the Client's name should not have a leading space