### PR TITLE
Fix item/location mismatch when shoppingsanity=collection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -423,7 +423,11 @@ class AE3World(World):
         # Fill remaining locations with Collectables
         unfilled : int = len(self.multiworld.get_unfilled_locations(self.player)) - len(self.item_pool)
         if self.options.shoppingsanity.value and self.options.hints_from_hintbooks.value:
-            unfilled -= len(set(SHOP_HINT_BOOK).difference(self.exclude_locations))
+            if self.options.shoppingsanity.value == 2:
+                hint_books = set([*SHOP_PERSISTENT_HINT_BOOK, *SHOP_COLLECTION_HINT_BOOK])
+            else:
+                hint_books = set(SHOP_HINT_BOOK)
+            unfilled -= len(hint_books.difference(self.exclude_locations))
 
         if unfilled < 0:
             raise OptionError(


### PR DESCRIPTION
In `create_items`, the hint book reservation always used `SHOP_HINT_BOOK`. In collection mode, 12/20 of those don't exist and are in `exclude_locations`, so only 8 slots were reserved. But pre_fill places 20 locked hint books (8 persistent + 12 collection), leaving 12 items without locations.

Use the same hint book list as `pre_fill` depending on shoppingsanity mode.

This was discovered using this [fuzzer hook](https://github.com/Eijebong/Archipelago-fuzzer/blob/27cf609dd6d20f7c9a2fbb27587979d1818735db/hooks/item_location_count.py) which failed ~10% of the time and now passes 100% of the time. Unfortunately doesn't have any effect on generation success rate