### PR TITLE
Fix some more generation issues

### DIFF
--- a/Regions.py
+++ b/Regions.py
@@ -69,7 +69,7 @@ def create_regions(world : "AE3World"):
         establish_entrance(world.player, entrance.name, parent, destination, ruleset)
 
     # Register Indirect Connections
-    if world.options.shoppingsanity.value > 1:
+    if world.options.shoppingsanity.value >= 1:
         farmable_stages : list[str] = [*STAGES_FARMABLE]
         if world.options.farm_logic_sneaky_borgs.value:
             farmable_stages.extend(STAGES_FARMABLE_SNEAKY_BORG)

--- a/Regions.py
+++ b/Regions.py
@@ -46,7 +46,8 @@ def create_regions(world : "AE3World"):
     blacklisted_entrances : list[Entrance] = [*world.logic_preference.blacklisted_entrances,
                                               *world.shop_rules.blacklisted_entrances]
 
-    # Connect Regions
+    # Connect Regions, building a name->Entrance lookup for indirect condition registration
+    entrance_objects : dict[str, Entrance] = {}
     for entrance in entrances:
         if entrance.name in blacklisted_entrances:
             continue
@@ -67,21 +68,41 @@ def create_regions(world : "AE3World"):
             ruleset = entrance_rules[entrance.name]
 
         establish_entrance(world.player, entrance.name, parent, destination, ruleset)
+        entrance_objects[entrance.name] = destination.entrances[-1]
 
     # Register Indirect Connections
+    farm_entrances : set[str] = set()
+    pgc_entrances : set[str] = set()
+
     if world.options.shoppingsanity.value >= 1:
+        farm_entrances.add(Stage.entrance_shop_expensive.value)
+        if world.options.cheap_items_minimum_requirement:
+            farm_entrances.add(Stage.entrance_travel_ab.value)
+
+    if world.options.post_game_condition_cameras:
+        pgc_entrances.update(entrance_rules.keys() & world.progression.pgc_entrance_names)
+
+        if world.options.shoppingsanity.value >= 1:
+            pgc_entrances.update(world.shop_rules.post_game_entrances)
+            if world.options.cheap_items_minimum_requirement.value >= 100:
+                pgc_entrances.add(Stage.entrance_travel_ab.value)
+
+    if farm_entrances:
         farmable_stages : list[str] = [*STAGES_FARMABLE]
         if world.options.farm_logic_sneaky_borgs.value:
             farmable_stages.extend(STAGES_FARMABLE_SNEAKY_BORG)
+        farmable_regions = [region for name, region in stages.items() if name in farmable_stages]
+        for ent_name in farm_entrances:
+            if ent_name in entrance_objects:
+                for region in farmable_regions:
+                    world.multiworld.register_indirect_condition(region, entrance_objects[ent_name])
 
-        # Register Shop Expensive Entrance as requiring an indirect condition
-        for entrance in stages[Stage.region_shop_expensive.value].entrances:
-            if entrance.name == Stage.entrance_shop_expensive.value:
-
-                for region in [region for name, region in stages.items() if name in farmable_stages]:
-                    world.multiworld.register_indirect_condition(region, entrance)
-
-            break
+    if pgc_entrances:
+        camera_regions = [region for name, region in stages.items() if name in CAMERAS_INDEX]
+        for ent_name in pgc_entrances:
+            if ent_name in entrance_objects:
+                for region in camera_regions:
+                    world.multiworld.register_indirect_condition(region, entrance_objects[ent_name])
 
     # Define Regions
     blacklist : list[str] = [stage for channel in world.options.blacklist_channel.value

--- a/__init__.py
+++ b/__init__.py
@@ -145,7 +145,7 @@ class AE3World(World):
         # Limit Post/Blacklist Channels to 8 items
         if len(self.options.post_channel.value) > 8:
             additive: bool = APHelper.additive.value in self.options.post_channel
-            new_post: list[str] = [*self.options.post_channel.value][:8]
+            new_post: list[str] = sorted(self.options.post_channel.value)[:8]
             if additive:
                 new_post.append(APHelper.additive.value)
 
@@ -198,9 +198,9 @@ class AE3World(World):
             self.progression.shuffle(self)
         # Directly Apply Channel Rules otherwise
         else:
-            self.progression.reorder(-1, [*self.options.blacklist_channel.value])
-            self.progression.reorder(-2, [*self.options.post_channel.value])
-            self.progression.reorder(-3, [*self.options.push_channel.value])
+            self.progression.reorder(-1, sorted(self.options.blacklist_channel.value))
+            self.progression.reorder(-2, sorted(self.options.post_channel.value))
+            self.progression.reorder(-3, sorted(self.options.push_channel.value))
             self.progression.regenerate_level_select_entrances()
 
         # Get Post Game Access Rule and exclude locations as necessary
@@ -330,7 +330,7 @@ class AE3World(World):
             current.difference_update(exclude)
             current.add(APHelper.nothing.value)
 
-            self.options.consolation_effects_whitelist.value = [*current]
+            self.options.consolation_effects_whitelist.value = sorted(current)
 
         self.exclude_locations = exclude_locations
 

--- a/data/Logic.py
+++ b/data/Logic.py
@@ -694,7 +694,7 @@ class Open(ProgressionMode):
 
     def reorder(self, set_interest : int, channels : list[str]):
         super().reorder(set_interest, channels)
-        if self.progression[1] != 0 and self.required_keys:
+        if len(self.progression) > 1 and self.progression[1] != 0 and self.required_keys:
             self.progression[1:1] = [0 for _ in range(self.required_keys)]
 
 class Randomize(ProgressionMode):

--- a/data/Logic.py
+++ b/data/Logic.py
@@ -330,9 +330,9 @@ class ProgressionMode:
         self.order = [*new_order]
 
         # Apply Channel Rules
-        self.reorder(-1, [*world.options.blacklist_channel.value])
-        self.reorder(-2, [*world.options.post_channel.value])
-        self.reorder(-3, [*world.options.push_channel.value])
+        self.reorder(-1, sorted(world.options.blacklist_channel.value))
+        self.reorder(-2, sorted(world.options.post_channel.value))
+        self.reorder(-3, sorted(world.options.push_channel.value))
 
         self.regenerate_level_select_entrances()
 
@@ -372,7 +372,7 @@ class ProgressionMode:
         # Re-insert Channels specified to be preserved in their vanilla indices
         if world.options.preserve_channel:
             preserve_indices : list[int] = [
-                LEVELS_BY_ORDER.index(channel) for channel in world.options.preserve_channel
+                LEVELS_BY_ORDER.index(channel) for channel in sorted(world.options.preserve_channel)
             ]
 
             if preserve_indices:
@@ -567,7 +567,7 @@ class Group(ProgressionMode):
         new_order : list[int] = self.generate_new_order(world)
 
         ## Pre-emptively remove Blacklisted Channels
-        blacklist : list[int] = [LEVELS_BY_ORDER.index(channel) for channel in world.options.blacklist_channel
+        blacklist : list[int] = [LEVELS_BY_ORDER.index(channel) for channel in sorted(world.options.blacklist_channel)
                                  if channel in LEVELS_BY_ORDER]
         new_order : list[int] = [_ for _ in new_order if _ not in blacklist]
 
@@ -619,8 +619,8 @@ class Group(ProgressionMode):
         self.order = [*new_order]
 
         # Apply Channel Rules
-        self.reorder(-2, [*world.options.post_channel.value])
-        self.reorder(-3, [*world.options.push_channel.value])
+        self.reorder(-2, sorted(world.options.post_channel.value))
+        self.reorder(-3, sorted(world.options.push_channel.value))
 
         # Update new Channel Destinations
         self.regenerate_level_select_entrances()
@@ -637,7 +637,7 @@ class World(ProgressionMode):
         new_order : list[int] = self.generate_new_order(world)
 
         # Pre-emptively remove Blacklisted Channels
-        blacklist : list[int] = [LEVELS_BY_ORDER.index(channel) for channel in world.options.blacklist_channel
+        blacklist : list[int] = [LEVELS_BY_ORDER.index(channel) for channel in sorted(world.options.blacklist_channel)
                                  if channel in LEVELS_BY_ORDER]
         if blacklist:
             new_order = [_ for _ in new_order if _ not in blacklist]
@@ -664,8 +664,8 @@ class World(ProgressionMode):
         self.order = [*new_order]
 
         # Apply Channel Rules
-        self.reorder(-2, [*world.options.post_channel.value])
-        self.reorder(-3, [*world.options.push_channel.value])
+        self.reorder(-2, sorted(world.options.post_channel.value))
+        self.reorder(-3, sorted(world.options.push_channel.value))
 
         # Update new Channel Destinations
         self.regenerate_level_select_entrances()

--- a/data/Logic.py
+++ b/data/Logic.py
@@ -475,6 +475,19 @@ class ProgressionMode:
         self.order = deepcopy(new_order)
         self.progression = deepcopy(new_progression)
 
+    @property
+    def pgc_entrance_names(self) -> set[str]:
+        post_game_set_idx = len(self.progression) - 2
+        if post_game_set_idx <= 0 or self.progression[post_game_set_idx] <= 0:
+            return set()
+
+        total_before = sum(self.progression[:post_game_set_idx]) + 1
+        return {
+            self.level_select_entrances[total_before + ch].name
+            for ch in range(self.progression[post_game_set_idx])
+            if total_before + ch < len(self.level_select_entrances)
+        }
+
     def generate_rules(self, world : 'AE3World') -> dict[str, Rulesets]:
         channel_rules : dict[str, Rulesets] = {}
 

--- a/data/Rules.py
+++ b/data/Rules.py
@@ -1936,13 +1936,15 @@ class ShopItemRules:
         if world.options.farm_logic_sneaky_borgs:
             farming_areas.extend([*STAGES_FARMABLE_SNEAKY_BORG])
 
+        post_game_start_index: int = sum(world.progression.progression[:-1])
+        post_game_end_index: int = post_game_start_index + world.progression.progression[-2]
         post_game_channels: list[str] = [LEVELS_BY_ORDER[channel] for channel in
-                                         world.progression.progression[:sum(world.progression.order[-3:-2])]]
+                                         world.progression.order[post_game_start_index:post_game_end_index]]
         post_game_areas: list[str] = []
         for channel in post_game_channels:
             post_game_areas.extend(STAGES_DIRECTORY_LABEL[channel])
 
-        return any(stage in post_game_areas for stage in farming_areas)
+        return any(stage not in post_game_areas for stage in farming_areas)
 
 # [<--- GOAL TARGETS --->]
 class Specter(GoalTarget):


### PR DESCRIPTION
The main commit in here is the indirect condition one. I wrote a [fuzzer hook](https://github.com/Eijebong/Archipelago-fuzzer/commit/4a5c89c5c6eec17f0c358827057eab9bba85c679) to detect missing indirect conditions and worked up from that. The rest is tiny fixes as well as determinism fixes (I ran after some nondeterminism for a while because indirect conditions can generate non determinism...)

This leaves the world at 0/10k failures when fuzzed with a world that has 100 locations empty, and 51/10k when fuzzed on its own.