### PR TITLE
Make UT sort checks by level

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -846,3 +846,7 @@ class AE3World(World):
                 self.exclude_locations = excluded_locations
 
         return is_in_ut
+
+    # Makes it so UT uses the region name before location name when sorting, functionally sorting by level
+    def custom_ut_sort(self, region_label: str, location_label: str) -> str | int:
+        return f"{region_label} {location_label}"


### PR DESCRIPTION
Added a function `custom_ut_sort(...)`, which tells UT to use the region names first when sorting the locations on the "Tracker Page", essentially sorting the locations so they appear grouped by level.

Example:
<img width="373" height="547" alt="image" src="https://github.com/user-attachments/assets/517e7921-d01e-4878-a5d4-2bcb5d9a256a" />
